### PR TITLE
Update typing for Python 3.13

### DIFF
--- a/lua_parser/astnodes.py
+++ b/lua_parser/astnodes.py
@@ -5,11 +5,11 @@
     Contains all Ast Node definitions.
 """
 from enum import Enum
-from typing import List, Optional
+from typing import Optional
 
 from antlr4.Token import CommonToken
 
-Comments = Optional[List["Comment"]]
+Comments = Optional[list["Comment"]]
 
 
 def _equal_dicts(d1, d2, ignore_keys):
@@ -148,9 +148,9 @@ class Expression(Node):
 class Block(Node):
     """Define a Lua Block."""
 
-    def __init__(self, body: List[Statement], **kwargs):
+    def __init__(self, body: list[Statement], **kwargs):
         super().__init__("Block", **kwargs)
-        self.body: List[Statement] = body
+        self.body: list[Statement] = body
 
 
 class Chunk(Node):
@@ -221,26 +221,26 @@ class Assign(Statement):
     """Lua global assignment statement.
 
     Attributes:
-        targets (`list<Node>`): List of targets.
-        values (`list<Node>`): List of values.
+        targets (`list<Node>`): list of targets.
+        values (`list<Node>`): list of values.
 
     """
 
-    def __init__(self, targets: List[Node], values: List[Node], **kwargs):
+    def __init__(self, targets: list[Node], values: list[Node], **kwargs):
         super().__init__("Assign", **kwargs)
-        self.targets: List[Node] = targets
-        self.values: List[Node] = values
+        self.targets: list[Node] = targets
+        self.values: list[Node] = values
 
 
 class LocalAssign(Assign):
     """Lua local assignment statement.
 
     Attributes:
-        targets (`list<Node>`): List of targets.
-        values (`list<Node>`): List of values.
+        targets (`list<Node>`): list of targets.
+        values (`list<Node>`): list of values.
     """
 
-    def __init__(self, targets: List[Node], values: List[Node], **kwargs):
+    def __init__(self, targets: list[Node], values: list[Node], **kwargs):
         super().__init__(targets, values, **kwargs)
         self._name: str = "LocalAssign"
 
@@ -250,7 +250,7 @@ class While(Statement):
 
     Attributes:
         test (`Node`): Expression to test.
-        body (`Block`): List of statements to execute.
+        body (`Block`): list of statements to execute.
     """
 
     def __init__(self, test: Expression, body: Block, **kwargs):
@@ -263,7 +263,7 @@ class Do(Statement):
     """Lua do end statement.
 
     Attributes:
-        body (`Block`): List of statements to execute.
+        body (`Block`): list of statements to execute.
     """
 
     def __init__(self, body: Block, **kwargs):
@@ -276,7 +276,7 @@ class Repeat(Statement):
 
     Attributes:
         test (`Node`): Expression to test.
-        body (`Block`): List of statements to execute.
+        body (`Block`): list of statements to execute.
     """
 
     def __init__(self, body: Block, test: Expression, **kwargs):
@@ -290,8 +290,8 @@ class ElseIf(Statement):
 
     Attributes:
         test (`Node`): Expression to test.
-        body (`list<Statement>`): List of statements to execute if test is true.
-        orelse (`list<Statement> or ElseIf`): List of statements or ElseIf if test if false.
+        body (`list<Statement>`): list of statements to execute if test is true.
+        orelse (`list<Statement> or ElseIf`): list of statements or ElseIf if test if false.
     """
 
     def __init__(self, test: Node, body: Block, orelse, **kwargs):
@@ -306,12 +306,12 @@ class If(Statement):
 
     Attributes:
         test (`Node`): Expression to test.
-        body (`Block`): List of statements to execute if test is true.
-        orelse (`list<Statement> or ElseIf`): List of statements or ElseIf if test if false.
+        body (`Block`): list of statements to execute if test is true.
+        orelse (`list<Statement> or ElseIf`): list of statements or ElseIf if test if false.
     """
 
     def __init__(
-        self, test: Expression, body: Block, orelse: List[Statement] or ElseIf, **kwargs
+        self, test: Expression, body: Block, orelse: list[Statement] or ElseIf, **kwargs
     ):
         super().__init__("If", **kwargs)
         self.test: Expression = test
@@ -377,7 +377,7 @@ class Fornum(Statement):
         start (`Expression`): Start index value.
         stop (`Expression`): Stop index value.
         step (`Expression`): Step value.
-        body (`Block`): List of statements to execute.
+        body (`Block`): list of statements to execute.
     """
 
     def __init__(
@@ -401,18 +401,18 @@ class Forin(Statement):
     """Define the for in lua statement.
 
     Attributes:
-        body (`Block`): List of statements to execute.
+        body (`Block`): list of statements to execute.
         iter (`list<Expression>`): Iterable expressions.
         targets (`list<Name>`): Start index value.
     """
 
     def __init__(
-        self, body: Block, iter: List[Expression], targets: List[Name], **kwargs
+        self, body: Block, iter: list[Expression], targets: list[Name], **kwargs
     ):
         super(Forin, self).__init__("Forin", **kwargs)
         self.body: Block = body
-        self.iter: List[Expression] = iter
-        self.targets: List[Name] = targets
+        self.iter: list[Expression] = iter
+        self.targets: list[Name] = targets
 
 
 class Call(Statement):
@@ -423,10 +423,10 @@ class Call(Statement):
         args (`list<Expression>`): Function call arguments.
     """
 
-    def __init__(self, func: Expression, args: List[Expression], **kwargs):
+    def __init__(self, func: Expression, args: list[Expression], **kwargs):
         super(Call, self).__init__("Call", **kwargs)
         self.func: Expression = func
-        self.args: List[Expression] = args
+        self.args: list[Expression] = args
 
 
 class Invoke(Statement):
@@ -439,12 +439,12 @@ class Invoke(Statement):
     """
 
     def __init__(
-        self, source: Expression, func: Expression, args: List[Expression], **kwargs
+        self, source: Expression, func: Expression, args: list[Expression], **kwargs
     ):
         super(Invoke, self).__init__("Invoke", **kwargs)
         self.source: Expression = source
         self.func: Expression = func
-        self.args: List[Expression] = args
+        self.args: list[Expression] = args
 
 
 class Function(Statement):
@@ -453,13 +453,13 @@ class Function(Statement):
     Attributes:
         name (`Expression`): Function name.
         args (`list<Expression>`): Function arguments.
-        body (`Block`): List of statements to execute.
+        body (`Block`): list of statements to execute.
     """
 
-    def __init__(self, name: Expression, args: List[Expression], body: Block, **kwargs):
+    def __init__(self, name: Expression, args: list[Expression], body: Block, **kwargs):
         super(Function, self).__init__("Function", **kwargs)
         self.name: Expression = name
-        self.args: List[Expression] = args
+        self.args: list[Expression] = args
         self.body: Block = body
 
 
@@ -469,13 +469,13 @@ class LocalFunction(Statement):
     Attributes:
         name (`Expression`): Function name.
         args (`list<Expression>`): Function arguments.
-        body (`list<Statement>`): List of statements to execute.
+        body (`list<Statement>`): list of statements to execute.
     """
 
-    def __init__(self, name: Expression, args: List[Expression], body: Block, **kwargs):
+    def __init__(self, name: Expression, args: list[Expression], body: Block, **kwargs):
         super(LocalFunction, self).__init__("LocalFunction", **kwargs)
         self.name: Expression = name
-        self.args: List[Expression] = args
+        self.args: list[Expression] = args
         self.body: Block = body
 
 
@@ -486,21 +486,21 @@ class Method(Statement):
         source (`Expression`): Source expression where method is defined.
         name (`Expression`): Function name.
         args (`list<Expression>`): Function arguments.
-        body (`Block`): List of statements to execute.
+        body (`Block`): list of statements to execute.
     """
 
     def __init__(
         self,
         source: Expression,
         name: Expression,
-        args: List[Expression],
+        args: list[Expression],
         body: Block,
         **kwargs
     ):
         super(Method, self).__init__("Method", **kwargs)
         self.source: Expression = source
         self.name: Expression = name
-        self.args: List[Expression] = args
+        self.args: list[Expression] = args
         self.body: Block = body
 
 
@@ -609,9 +609,9 @@ class Table(Expression):
         fields (`list<Field>`): Table fields.
     """
 
-    def __init__(self, fields: List[Field], **kwargs):
+    def __init__(self, fields: list[Field], **kwargs):
         super().__init__("Table", **kwargs)
-        self.fields: List[Field] = fields
+        self.fields: list[Field] = fields
 
 
 class Dots(Expression):
@@ -626,12 +626,12 @@ class AnonymousFunction(Expression):
 
     Attributes:
         args (`list<Expression>`): Function arguments.
-        body (`Block`): List of statements to execute.
+        body (`Block`): list of statements to execute.
     """
 
-    def __init__(self, args: List[Expression], body: Block, **kwargs):
+    def __init__(self, args: list[Expression], body: Block, **kwargs):
         super(AnonymousFunction, self).__init__("AnonymousFunction", **kwargs)
-        self.args: List[Expression] = args
+        self.args: list[Expression] = args
         self.body: Block = body
 
 

--- a/lua_parser/builder.py
+++ b/lua_parser/builder.py
@@ -5,7 +5,7 @@ from antlr4 import InputStream, CommonTokenStream
 
 from lua_parser.astnodes import *
 from lua_parser.parser.LuaLexer import LuaLexer
-from typing import List, Tuple
+from typing import Optional
 from antlr4.Token import Token
 
 
@@ -205,8 +205,8 @@ class Builder:
         self._last_expr_type: Optional[int] = None
 
         # following stack are used to backup values
-        self._index_stack: List[int] = []
-        self._right_index_stack: List[int] = []
+        self._index_stack: list[int] = []
+        self._right_index_stack: list[int] = []
         self.text: str = ""  # last token text
         self.type: int = -1  # last token type
 
@@ -214,10 +214,10 @@ class Builder:
         self._expected = []
 
         # comments waiting to be inserted into ast nodes
-        self._comments_index_stack: List[int] = []
-        self.comments: List[Comment] = []
+        self._comments_index_stack: list[int] = []
+        self.comments: list[Comment] = []
         self._hidden_handled: bool = False
-        self._hidden_handled_stack: List[bool] = []
+        self._hidden_handled_stack: list[bool] = []
 
     @property
     def _LT(self) -> CommonToken:
@@ -309,7 +309,7 @@ class Builder:
     def prev_is(self, type_to_seek) -> bool:
         return self._stream.LT(-1).type == type_to_seek
 
-    def next_in_rc(self, types: List[int], hidden_right: bool = True) -> bool:
+    def next_in_rc(self, types: list[int], hidden_right: bool = True) -> bool:
         token = self._stream.LT(1)
         tok_type: int = token.type
         self._right_index = self._stream.index
@@ -324,7 +324,7 @@ class Builder:
         self._expected.extend(types)
         return False
 
-    def next_in(self, types: List[int]) -> bool:
+    def next_in(self, types: list[int]) -> bool:
         if self._stream.LT(1).type in types:
             return True
         else:
@@ -398,7 +398,7 @@ class Builder:
             return []
 
         idx = 0
-        comments: List[Comment] = []
+        comments: list[Comment] = []
 
         # search first comment
         while idx < len(self.comments) and self.comments[idx] is None:
@@ -547,7 +547,7 @@ class Builder:
 
         return self.failure()
 
-    def parse_var_list(self) -> List[Expression] or bool:
+    def parse_var_list(self) -> list[Expression] | bool:
         lua_vars = []
         self.save()
         var = self.parse_var()
@@ -709,8 +709,8 @@ class Builder:
 
         return self.failure()
 
-    def parse_expr_list(self) -> List[Expression] or bool:
-        expr_list: List[Expression] = []
+    def parse_expr_list(self) -> list[Expression] | bool:
+        expr_list: list[Expression] = []
         self.save()
         expr = self.parse_expr()
         if expr:
@@ -1034,8 +1034,8 @@ class Builder:
                     self.abort()
         return self.failure()
 
-    def parse_param_list(self) -> List[Expression] or bool:
-        param_list: List[Expression] = self.parse_name_list()
+    def parse_param_list(self) -> list[Expression] | bool:
+        param_list: list[Expression] = self.parse_name_list()
         if param_list:
             self.save()
             if self.next_is_rc(Tokens.COMMA) and self.next_is_rc(Tokens.VARARGS):
@@ -1054,9 +1054,9 @@ class Builder:
         self.success()
         return []
 
-    def parse_name_list(self) -> List[Name] or bool:
+    def parse_name_list(self) -> list[Name] | bool:
         self.save()
-        names: List[Name] = []
+        names: list[Name] = []
         if self.next_is_rc(Tokens.NAME):
             names.append(
                 Name(
@@ -1478,7 +1478,7 @@ class Builder:
 
         return self.failure()
 
-    def parse_field_list(self) -> List[Field] or bool:
+    def parse_field_list(self) -> list[Field] | bool:
         field_list = []
         self.save()
         field, _ = self.parse_field()
@@ -1509,7 +1509,7 @@ class Builder:
             return field_list
         return self.failure()
 
-    def parse_field(self) -> Tuple[Field or bool, Comments]:
+    def parse_field(self) -> tuple[Field | bool, Comments]:
         self.save()
 
         if self.next_is_rc(Tokens.OBRACK):

--- a/lua_parser/parser/LuaLexer.py
+++ b/lua_parser/parser/LuaLexer.py
@@ -1,7 +1,7 @@
 # Generated from Lua.g4 by ANTLR 4.7.1
 from antlr4 import *
 from io import StringIO
-from typing.io import TextIO
+from typing import TextIO
 import sys
 
 


### PR DESCRIPTION
## Summary
- modernize type hints in `lua_parser`
- swap deprecated `typing.io.TextIO` import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'antlr4')*

------
https://chatgpt.com/codex/tasks/task_e_687eca72f4cc832dbb32b1034a365f4d