### PR TITLE
Add setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # LuaTaint
 An automated static taint analysis tool for the Lua web framework.
+
+## Setup
+
+Install the Python dependencies listed in `requirements.txt` before running the
+tool:
+
+```bash
+pip install -r requirements.txt
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+antlr4-python3-runtime
+psutil


### PR DESCRIPTION
## Summary
- document installation instructions

## Testing
- `python3 -m unittest discover -v` *(fails: ModuleNotFoundError: No module named 'antlr4')*

------
https://chatgpt.com/codex/tasks/task_e_687ed3729354832d8fbe26f6815feaef