### PR TITLE
Work around typing.io import issue

### DIFF
--- a/lua_parser/__init__.py
+++ b/lua_parser/__init__.py
@@ -1,1 +1,18 @@
+"""Lua parser package initialization."""
+
+import types
+import typing
+
+# ---------------------------------------------------------------------------
+# Compatibility shim
+# ---------------------------------------------------------------------------
+# Some environments install the ``typing`` backport from PyPI, which shadows
+# the standard library version.  The backport does not provide ``typing.io``
+# that newer versions of ``antlr4`` expect.  When missing, importing the
+# runtime raises ``ModuleNotFoundError: No module named 'typing.io'``.  To keep
+# the parser functional we ensure ``typing.io`` is defined before importing
+# any antlr modules.
+if not hasattr(typing, "io"):
+    typing.io = types.SimpleNamespace(TextIO=typing.TextIO)
+
 __version__ = "3.1.1"


### PR DESCRIPTION
## Summary
- ensure typing.io is defined when importing the package
- rely on package initialization instead of patching ast.py directly

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687edbc03270832d8512dd061100223a