### PR TITLE
Fix typing.io issue with Python 3.13

### DIFF
--- a/lua_parser/__init__.py
+++ b/lua_parser/__init__.py
@@ -1,5 +1,6 @@
 """Lua parser package initialization."""
 
+import sys
 import types
 import typing
 
@@ -13,6 +14,8 @@ import typing
 # the parser functional we ensure ``typing.io`` is defined before importing
 # any antlr modules.
 if not hasattr(typing, "io"):
-    typing.io = types.SimpleNamespace(TextIO=typing.TextIO)
+    _typing_io = types.SimpleNamespace(TextIO=typing.TextIO)
+    typing.io = _typing_io
+    sys.modules["typing.io"] = _typing_io
 
 __version__ = "3.1.1"


### PR DESCRIPTION
## Summary
- ensure `typing.io` is provided for older antlr versions

## Testing
- `PYTHONPATH=.:$PYTHONPATH pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687edf02f474832dbf60789eba7efae6