### PR TITLE
Add sanity check for Lua files

### DIFF
--- a/lua_parser/tests/test_compiled_file_detection.py
+++ b/lua_parser/tests/test_compiled_file_detection.py
@@ -1,0 +1,24 @@
+import os
+import tempfile
+from core.ast_helper import is_compiled_lua
+from lua_parser.utils import tests
+
+
+class CompiledFileDetectionTest(tests.TestCase):
+    def test_detect_compiled_lua(self):
+        with tempfile.NamedTemporaryFile(delete=False, suffix='.lua') as f:
+            f.write(b'\x1bLuaQ')
+            path = f.name
+        try:
+            self.assertTrue(is_compiled_lua(path))
+        finally:
+            os.unlink(path)
+
+    def test_source_file_not_compiled(self):
+        with tempfile.NamedTemporaryFile('w', delete=False, suffix='.lua') as f:
+            f.write('print("hello")')
+            path = f.name
+        try:
+            self.assertFalse(is_compiled_lua(path))
+        finally:
+            os.unlink(path)


### PR DESCRIPTION
## Summary
- ensure discover_files skips non-Lua targets
- warn users when non-Lua files are passed to the CLI
- detect compiled Lua bytecode before parsing and skip those files
- handle IO errors when reading files
- add tests for compiled Lua detection

## Testing
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_687ee3f8e950832da5e4b9eb5517dcda