### PR TITLE
Fix fixed point performance

### DIFF
--- a/analysis/fixed_point.py
+++ b/analysis/fixed_point.py
@@ -1,10 +1,18 @@
 """This module implements the fixed point algorithm."""
+from collections import deque
+import logging
+import os
+import psutil
+
 from .constraint_table import constraint_table
 from .reaching_definitions_taint import ReachingDefinitionsTaintAnalysis
 
 
-class FixedPointAnalysis():
-    """Run the fix point analysis."""
+log = logging.getLogger(__name__)
+
+
+class FixedPointAnalysis:
+    """Run the fix point analysis using a worklist algorithm."""
 
     def __init__(self, cfg):
         """Fixed point analysis.
@@ -15,19 +23,41 @@ class FixedPointAnalysis():
         self.cfg = cfg
 
     def fixpoint_runner(self):
-        """Work list algorithm that runs the fixpoint algorithm."""
-        q = self.cfg.nodes
+        """Iteratively update nodes until a fixpoint is reached.
 
-        while q != []:
-            x_i = constraint_table[q[0]]  # x_i = q[0].old_constraint
-            self.analysis.fixpointmethod(q[0])  # y = F_i(x_1, ..., x_n);
-            y = constraint_table[q[0]]  # y = q[0].new_constraint
+        A deque is used for the worklist to avoid the costly list slicing that
+        previously led to excessive memory usage on large graphs.
+        """
+        worklist = deque(self.cfg.nodes)
+        in_worklist = set(worklist)
+        iteration = 0
+        process = psutil.Process(os.getpid())
 
-            if y != x_i:
-                for node in self.analysis.dep(q[0]):  # for (v in dep(v_i))
-                    q.append(node)  # q.append(v):
-                constraint_table[q[0]] = y  # q[0].old_constraint = q[0].new_constraint # x_i = y
-            q = q[1:]  # q = q.tail()  # The list minus the head
+        while worklist:
+            node = worklist.popleft()
+            in_worklist.discard(node)
+
+            if iteration % 100 == 0:
+                mem_mb = process.memory_info().rss / (1024 * 1024)
+                log.debug(
+                    "Iter %d: processing %s; worklist size %d; memory %.1f MB",
+                    iteration,
+                    getattr(node, "label", str(node)),
+                    len(worklist),
+                    mem_mb,
+                )
+
+            old_constraint = constraint_table[node]
+            self.analysis.fixpointmethod(node)
+            new_constraint = constraint_table[node]
+
+            if new_constraint != old_constraint:
+                for dep_node in self.analysis.dep(node):
+                    if dep_node not in in_worklist:
+                        worklist.append(dep_node)
+                        in_worklist.add(dep_node)
+
+            iteration += 1
 
 
 def analyse(cfg_list):


### PR DESCRIPTION
## Summary
- replace slice-based queue in `FixedPointAnalysis` with `collections.deque`
- clarify code comments and variable names for worklist algorithm
- avoid duplicate nodes in worklist to reduce memory churn
- add debug logging that tracks iteration progress and memory usage

## Testing
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68815de92b08832da1cea1eb5113214a