### PR TITLE
Improve memory and failure diagnostics

### DIFF
--- a/analysis/fixed_point.py
+++ b/analysis/fixed_point.py
@@ -33,6 +33,8 @@ class FixedPointAnalysis:
         iteration = 0
         process = psutil.Process(os.getpid())
 
+        log.debug("Starting fixpoint on %s with %d nodes", getattr(self.cfg, 'filename', '?'), len(worklist))
+
         while worklist:
             node = worklist.popleft()
             in_worklist.discard(node)
@@ -65,3 +67,5 @@ def analyse(cfg_list):
     for cfg in cfg_list:
         analysis = FixedPointAnalysis(cfg)
         analysis.fixpoint_runner()
+        mem_mb = psutil.Process(os.getpid()).memory_info().rss / (1024 * 1024)
+        log.debug("Completed fixpoint on %s; memory usage %.1f MB", getattr(cfg, 'filename', '?'), mem_mb)

--- a/cfg/stmt_visitor.py
+++ b/cfg/stmt_visitor.py
@@ -436,10 +436,10 @@ class StmtVisitor(ast.NodeVisitor):
             else:
                 label = LabelVisitor()
                 label.visit(node)
-                log.warn(
-                    'Assignment not properly handled in %s. Could result in not finding a vulnerability.'
-                    'Assignment: %s',
+                log.warning(
+                    'Assignment not properly handled at %s:%s. Could result in not finding a vulnerability. Assignment: %s',
                     getattr(self, 'filenames', ['?'])[0],
+                    getattr(node, 'line', '?'),
                     label.result,
                 )
                 return self.append_node(AssignmentNode(
@@ -482,11 +482,11 @@ class StmtVisitor(ast.NodeVisitor):
             else:
                 label = LabelVisitor()
                 label.visit(node)
-                log.warn(
-                    'Assignment not properly handled in %s. Could result in not finding a vulnerability.'
-                    'Assignment: %s',
+                log.warning(
+                    'Assignment not properly handled at %s:%s. Could result in not finding a vulnerability. Assignment: %s',
                     getattr(self, 'filenames', ['?'])[0],
-                    label.result, # self.label.result
+                    getattr(node, 'line', '?'),
+                    label.result,  # self.label.result
                 )
                 return self.append_node(AssignmentNode(
                     label.result,


### PR DESCRIPTION
## Summary
- log memory usage throughout the main workflow
- provide more detailed messages for unhandled assignments
- report memory when running fixpoint analysis

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68816ed5a188832d807d463bb288c4bd